### PR TITLE
Bump kernel/mocaccino-modules to 5.10.1

### DIFF
--- a/packages/kernels/mocaccino/modules/definition.yaml
+++ b/packages/kernels/mocaccino/modules/definition.yaml
@@ -1,6 +1,6 @@
 name: mocaccino-modules
 category: kernel
-version: "5.10"
+version: "5.10.1"
 prefix: linux
 suffix: mocaccino
 arch: "x86_64"
@@ -10,7 +10,7 @@ labels:
   autobump.strategy: "custom"
   autobump.prefix: "prefix"
   autobump.hook: |
-            curl -Ls https://kernel.org/releases.json | jq -cr '[ .releases[] | select(.moniker == "stable") ][0].version'
+    curl -Ls https://kernel.org/releases.json | jq -cr '[ .releases[] | select(.moniker == "stable") ][0].version'
   autobump.version_hook: |
-            curl -Ls https://kernel.org/releases.json | jq -cr '[ .releases[] | select(.moniker == "stable") ][0].version'
-  package.version: "5.10"
+    curl -Ls https://kernel.org/releases.json | jq -cr '[ .releases[] | select(.moniker == "stable") ][0].version'
+  package.version: "5.10.1"


### PR DESCRIPTION
![z-index](./images/z-index.png)