### PR TITLE
Bump kernel/mocaccino-sources to 5.10.5

### DIFF
--- a/packages/kernels/mocaccino/sources/definition.yaml
+++ b/packages/kernels/mocaccino/sources/definition.yaml
@@ -1,6 +1,6 @@
 name: mocaccino-sources
 category: kernel
-version: "5.10.4"
+version: "5.10.6"
 prefix: linux
 suffix: mocaccino
 labels:
@@ -12,4 +12,4 @@ labels:
     curl -Ls https://kernel.org/releases.json | jq -cr '[ .releases[] | select(.moniker == "stable") ][0].version'
   autobump.version_hook: |
     curl -Ls https://kernel.org/releases.json | jq -cr '[ .releases[] | select(.moniker == "stable") ][0].version'
-  package.version: "5.10.4"
+  package.version: "5.10.6"


### PR DESCRIPTION
Because it was now off the hook.