### PR TITLE
Bump kernel/mocaccino-lts-minimal to 5.4.87

### DIFF
--- a/packages/kernels/mocaccino-lts/minimal/definition.yaml
+++ b/packages/kernels/mocaccino-lts/minimal/definition.yaml
@@ -1,6 +1,6 @@
 name: mocaccino-lts-minimal
 category: kernel
-version: "5.4.86+4"
+version: "5.10.20"
 kernelprefix: kernel-vanilla
 arch: "x86_64"
 suffix: mocaccino
@@ -14,4 +14,4 @@ labels:
     curl -Ls https://kernel.org/releases.json | jq -cr '[ .releases[] | select(.moniker == "longterm") ][0].version'
   autobump.version_hook: |
     curl -Ls https://kernel.org/releases.json | jq -cr '[ .releases[] | select(.moniker == "longterm") ][0].version'
-  package.version: "5.4.86"
+  package.version: "5.10.20"


### PR DESCRIPTION
git is one byte short of a four-letter word