### PR TITLE
Bump kernel/mocaccino-modules to 5.11.4

### DIFF
--- a/packages/kernels/mocaccino/modules/definition.yaml
+++ b/packages/kernels/mocaccino/modules/definition.yaml
@@ -1,6 +1,6 @@
 name: mocaccino-modules
 category: kernel
-version: "5.11.3"
+version: "5.11.11"
 prefix: linux
 suffix: mocaccino
 arch: "x86_64"
@@ -13,4 +13,4 @@ labels:
     curl -Ls https://kernel.org/releases.json | jq -cr '[ .releases[] | select(.moniker == "stable") ][0].version'
   autobump.version_hook: |
     curl -Ls https://kernel.org/releases.json | jq -cr '[ .releases[] | select(.moniker == "stable") ][0].version'
-  package.version: "5.11.3"
+  package.version: "5.11.11"


### PR DESCRIPTION
Why did the commit cross the rebase? To git to the other repo