### PR TITLE
Prevent holding partitions hostage

### DIFF
--- a/packages/initramfs/loader.sh
+++ b/packages/initramfs/loader.sh
@@ -111,7 +111,8 @@ search_overlay() {
       OVERLAY_MNT=$IMAGE_MNT
       UPPER_DIR=$DEFAULT_UPPER_DIR
       WORK_DIR=$DEFAULT_WORK_DIR
-    
+    else
+      umount $DEVICE
     fi
 
     if [ "$OVERLAY_DIR" != "" -a "$UPPER_DIR" != "" -a "$WORK_DIR" != "" ] ; then


### PR DESCRIPTION
Allow Script to unmount partition when rootfs.squashfs file is not found.