### PR TITLE
Bump kernel/mocaccino-modules to 5.11.12

### DIFF
--- a/packages/kernels/mocaccino/modules/definition.yaml
+++ b/packages/kernels/mocaccino/modules/definition.yaml
@@ -1,6 +1,6 @@
 name: mocaccino-modules
 category: kernel
-version: "5.11.11"
+version: "5.11.13"
 prefix: linux
 suffix: mocaccino
 arch: "x86_64"
@@ -13,4 +13,4 @@ labels:
     curl -Ls https://kernel.org/releases.json | jq -cr '[ .releases[] | select(.moniker == "stable") ][0].version'
   autobump.version_hook: |
     curl -Ls https://kernel.org/releases.json | jq -cr '[ .releases[] | select(.moniker == "stable") ][0].version'
-  package.version: "5.11.11"
+  package.version: "5.11.13"


### PR DESCRIPTION
Commits are not objects of love, and should not be judged by their size.