### PR TITLE
Bump kernel/mocaccino-lts-sources to 5.10.36

### DIFF
--- a/packages/kernels/mocaccino-lts/sources/definition.yaml
+++ b/packages/kernels/mocaccino-lts/sources/definition.yaml
@@ -1,6 +1,6 @@
 name: mocaccino-lts-sources
 category: kernel
-version: "5.10.35"
+version: "5.10.36"
 prefix: linux
 suffix: mocaccino
 labels:
@@ -12,4 +12,4 @@ labels:
     curl -Ls https://kernel.org/releases.json | jq -cr '[ .releases[] | select(.moniker == "longterm") ][0].version'
   autobump.version_hook: |
     curl -Ls https://kernel.org/releases.json | jq -cr '[ .releases[] | select(.moniker == "longterm") ][0].version'
-  package.version: "5.10.35"
+  package.version: "5.10.36"


### PR DESCRIPTION
Chuck Norris don’t need passwords to access your system, he simply types \* and system gives him access.