### PR TITLE
Bump kernel/mocaccino-initramfs to 5.12.6

### DIFF
--- a/packages/initramfs/collection.yaml
+++ b/packages/initramfs/collection.yaml
@@ -2,7 +2,7 @@ packages:
   - category: "kernel"
     name: "mocaccino-initramfs"
     modules_name: "mocaccino-modules"
-    version: "5.12.5"
+    version: "5.12.9"
     git_sha: e80e77438c627981b266734c03e23dcf8a60014e
     golang_version: "1.15.6"
     arch: "amd64"
@@ -15,7 +15,7 @@ packages:
         curl -Ls https://kernel.org/releases.json | jq -cr '[ .releases[] | select(.moniker == "stable") ][0].version'
       autobump.version_hook: |
         curl -Ls https://kernel.org/releases.json | jq -cr '[ .releases[] | select(.moniker == "stable") ][0].version'
-      package.version: "5.12.5"
+      package.version: "5.12.9"
   - category: "kernel"
     name: "mocaccino-lts-initramfs"
     modules_name: "mocaccino-lts-modules"


### PR DESCRIPTION
git-bisect: The good, the bad and the... uhh... skip