### PR TITLE
Bump kernel/mocaccino-lts-modules to 5.10.39

### DIFF
--- a/packages/kernels/mocaccino-lts/modules/definition.yaml
+++ b/packages/kernels/mocaccino-lts/modules/definition.yaml
@@ -1,6 +1,6 @@
 name: mocaccino-lts-modules
 category: kernel
-version: "5.10.38"
+version: "5.10.42"
 prefix: linux
 arch: "x86_64"
 suffix: mocaccino
@@ -13,4 +13,4 @@ labels:
     curl -Ls https://kernel.org/releases.json | jq -cr '[ .releases[] | select(.moniker == "longterm") ][0].version'
   autobump.version_hook: |
     curl -Ls https://kernel.org/releases.json | jq -cr '[ .releases[] | select(.moniker == "longterm") ][0].version'
-  package.version: "5.10.38"
+  package.version: "5.10.42"


### PR DESCRIPTION
git: where we dropped our trunks and all have masters