### PR TITLE
Fix softlink command

### DIFF
--- a/packages/kernels/mocaccino/finalize.yaml
+++ b/packages/kernels/mocaccino/finalize.yaml
@@ -1,5 +1,5 @@
 install:
 - depmod -a {{ index .Values.labels "package.version" }}-mocaccino || true
 - rm -rf /boot/bzImage || true
-- cd /boot && ln -s kernel-* bzImage
+- cd /boot && ln -s kernel-vanilla-x86_64-{{ .Values.version }}-mocaccino bzImage
 - kernel-updater || true


### PR DESCRIPTION
soft link finalization script fails.

construction warning Failed running finalizer for kernel/mocaccino-lts-full-5.10.38 Failed running command: ln: target 'bzImage': No such file or directory
: exit status 1
Error: 2 errors occurred:
* Failed running command: ln: target 'bzImage': No such file or directory
: exit status 1
* Failed running command: ln: target 'bzImage': No such file or directory
: exit status 1