### PR TITLE
tweak initramfs name

### DIFF
--- a/packages/initramfs/build.yaml
+++ b/packages/initramfs/build.yaml
@@ -79,8 +79,8 @@ steps:
    xz --check=crc32 -9 --lzma2=dict=1MiB \
       --stdout initramfs.cpio \
       | dd conv=sync bs=512 \
-      of=/boot/{{.Values.name}}-{{.Values.version}}
-- cd /boot/ && ln -s {{.Values.name}}-{{.Values.version}} Initrd
+      of=/boot/initramfs-vanilla-x86_64-{{.Values.version}}-mocaccino
+- cd /boot/ && ln -s initramfs-vanilla-x86_64-{{.Values.version}}-mocaccino Initrd
 excludes:
 - ^/luetbuild
 - ^/root


### PR DESCRIPTION
fixes grub2-mkconfig detection.