### PR TITLE
Bump kernel/mocaccino-lts-modules to 5.10.43

### DIFF
--- a/packages/kernels/mocaccino-lts/modules/definition.yaml
+++ b/packages/kernels/mocaccino-lts/modules/definition.yaml
@@ -1,6 +1,6 @@
 name: mocaccino-lts-modules
 category: kernel
-version: "5.10.42"
+version: "5.10.49"
 prefix: linux
 arch: "x86_64"
 suffix: mocaccino
@@ -13,4 +13,4 @@ labels:
     curl -Ls https://kernel.org/releases.json | jq -cr '[ .releases[] | select(.moniker == "longterm") ][0].version'
   autobump.version_hook: |
     curl -Ls https://kernel.org/releases.json | jq -cr '[ .releases[] | select(.moniker == "longterm") ][0].version'
-  package.version: "5.10.42"
+  package.version: "5.10.49"


### PR DESCRIPTION
git-clone has nothing to do with reproduction. So stop that.