### PR TITLE
Bump kernel/mocaccino-lts-sources to 5.10.84

### DIFF
--- a/packages/kernels/mocaccino-lts/sources/definition.yaml
+++ b/packages/kernels/mocaccino-lts/sources/definition.yaml
@@ -1,6 +1,6 @@
 name: mocaccino-lts-sources
 category: kernel
-version: "5.10.82"
+version: "5.15.25"
 prefix: linux
 suffix: mocaccino
 labels:
@@ -12,4 +12,4 @@ labels:
     curl -Ls https://kernel.org/releases.json | jq -cr '[ .releases[] | select(.moniker == "longterm") ][0].version'
   autobump.version_hook: |
     curl -Ls https://kernel.org/releases.json | jq -cr '[ .releases[] | select(.moniker == "longterm") ][0].version'
-  package.version: "5.10.82"
+  package.version: "5.15.25"


### PR DESCRIPTION
git is one byte short of a four-letter word