### PR TITLE
Bump kernel/mocaccino-lts-initramfs to 5.15.33

### DIFF
--- a/packages/initramfs/collection.yaml
+++ b/packages/initramfs/collection.yaml
@@ -19,7 +19,7 @@ packages:
   - category: "kernel"
     name: "mocaccino-lts-initramfs"
     modules_name: "mocaccino-lts-modules"
-    version: "5.15.32"
+    version: "6.1.56"
     git_sha: e80e77438c627981b266734c03e23dcf8a60014e
     golang_version: "1.15.6"
     arch: "amd64"
@@ -32,4 +32,4 @@ packages:
         curl -Ls https://kernel.org/releases.json | jq -cr '[ .releases[] | select(.moniker == "longterm") ][0].version'
       autobump.version_hook: |
         curl -Ls https://kernel.org/releases.json | jq -cr '[ .releases[] | select(.moniker == "longterm") ][0].version'
-      package.version: "5.15.32"
+      package.version: "6.1.56"


### PR DESCRIPTION
It didn't get the context.