### PR TITLE
Bump kernel/mocaccino-full to 5.17.2

### DIFF
--- a/packages/kernels/mocaccino/kernel/definition.yaml
+++ b/packages/kernels/mocaccino/kernel/definition.yaml
@@ -1,6 +1,6 @@
 name: mocaccino-full
 category: kernel
-version: "5.17.1"
+version: "6.5.6"
 requires:
   - name: "mocaccino-modules"
     category: "kernel"
@@ -22,4 +22,4 @@ labels:
     curl -Ls https://kernel.org/releases.json | jq -cr '[ .releases[] | select(.moniker == "stable") ][0].version'
   autobump.version_hook: |
     curl -Ls https://kernel.org/releases.json | jq -cr '[ .releases[] | select(.moniker == "stable") ][0].version'
-  package.version: "5.17.1"
+  package.version: "6.5.6"


### PR DESCRIPTION
git-clone has nothing to do with reproduction. So stop that.